### PR TITLE
feat: speed up MulVectorMatrix by over 90%

### DIFF
--- a/rref.go
+++ b/rref.go
@@ -63,13 +63,8 @@ func MulVectorMatrix(v []byte, m Matrix) ([]byte, error) {
 	}
 
 	ret := make([]byte, len(m[0]))
-	var scratch byte
-	for i := 0; i < len(m[0]); i++ {
-		scratch = 0
-		for j, vectorVal := range v {
-			scratch ^= galMultiply(m[j][i], vectorVal)
-		}
-		ret[i] = scratch
+	for i, element := range v {
+		galMulSliceXor(element, m[i], ret, &defaultOptions)
 	}
 
 	return ret, nil


### PR DESCRIPTION
We don't need to use naive multiplication here. Instead, we can observe that for a vector `v` and matrix `M` of compatible dimensions, computing `v.M` can be done in just one pass over `v` if you have vector instructions. Specifically, you:
- scale the entire `i`th row of `M` by the `i`th element in `v`
- add all the rows together (which, of course, is just XOR-ing them for us)

This can be done in one pass -- you scale and add, scale and add. Specifically, the optimized `galMulSliceXor` method does _both_ these operations for us: given an element `scale`, an input vector `in`, and an output vector `out`, it computes `XOR(out, scale*in)`. This allows us to compute the product of a vector and a matrix (or the product of 2 matrices, for that matter) much faster.