### PR TITLE
chore: export Galois slice operations

### DIFF
--- a/mulslice.go
+++ b/mulslice.go
@@ -1,0 +1,13 @@
+package reedsolomon
+
+func GalMulSlice(c byte, in, out []byte) {
+	galMulSlice(c, in, out, &defaultOptions)
+}
+
+func GalMulSliceXor(c byte, in, out []byte) {
+	galMulSliceXor(c, in, out, &defaultOptions)
+}
+
+func Inv(e byte) byte {
+	return invTable[e]
+}


### PR DESCRIPTION
This allows us to move all custom logic we want into our own codebase, leaving this repo as just a fork with 3 newly exported methods.